### PR TITLE
投稿の更新と削除

### DIFF
--- a/handlers/post.go
+++ b/handlers/post.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/jinzhu/gorm"
 	"github.com/roaris/go_sns_api/models"
+	"gopkg.in/go-playground/validator.v9"
 )
 
 type PostRequest struct {
@@ -51,5 +52,29 @@ func PostCreate(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func PostUpdate(w http.ResponseWriter, r *http.Request) {
+	// パスパラメータの取得
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["id"])
+
+	// リクエストボディをPostRequestに変換する
+	body := make([]byte, r.ContentLength)
+	r.Body.Read(body)
+	var postRequest PostRequest
+	json.Unmarshal(body, &postRequest)
+
+	err := models.UpdatePost(id, postRequest.Content)
+
+	if gorm.IsRecordNotFoundError(err) {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	} else if _, ok := err.(validator.ValidationErrors); ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -15,12 +15,6 @@ type PostRequest struct {
 }
 
 func PostShow(w http.ResponseWriter, r *http.Request) {
-	// GETリクエストのみ受け付ける
-	if r.Method != "GET" {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
 	// パスパラメータの取得
 	vars := mux.Vars(r)
 	id, _ := strconv.Atoi(vars["id"])
@@ -39,12 +33,6 @@ func PostShow(w http.ResponseWriter, r *http.Request) {
 }
 
 func PostCreate(w http.ResponseWriter, r *http.Request) {
-	// POSTリクエストのみ受け付ける
-	if r.Method != "POST" {
-		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
 	// application/jsonのみ受け付ける
 	if r.Header.Get("Content-Type") != "application/json" {
 		w.WriteHeader(http.StatusBadRequest)

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -78,3 +78,17 @@ func PostUpdate(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func PostDelete(w http.ResponseWriter, r *http.Request) {
+	// パスパラメータの取得
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["id"])
+
+	err := models.DeletePost(id)
+	if gorm.IsRecordNotFoundError(err) {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/main.go
+++ b/main.go
@@ -8,12 +8,14 @@ import (
 )
 
 func main() {
-	router := mux.NewRouter()
-	router.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+	r := mux.NewRouter()
+	r.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("pong"))
 	})
-	router.HandleFunc("/api/v1/posts/{id:[0-9]+}", handlers.PostShow)
-	router.HandleFunc("/api/v1/posts", handlers.PostCreate)
-	http.ListenAndServe(":8080", router)
+
+	v1r := r.PathPrefix("/api/v1").Subrouter()
+	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostShow)
+	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(handlers.PostCreate)
+	http.ListenAndServe(":8080", r)
 }

--- a/main.go
+++ b/main.go
@@ -17,5 +17,6 @@ func main() {
 	v1r := r.PathPrefix("/api/v1").Subrouter()
 	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostShow)
 	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(handlers.PostCreate)
+	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostUpdate)
 	http.ListenAndServe(":8080", r)
 }

--- a/main.go
+++ b/main.go
@@ -18,5 +18,6 @@ func main() {
 	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostShow)
 	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(handlers.PostCreate)
 	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostUpdate)
+	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostDelete)
 	http.ListenAndServe(":8080", r)
 }

--- a/models/post.go
+++ b/models/post.go
@@ -29,3 +29,19 @@ func CreatePost(content string) (err error) {
 	db.Create(&post)
 	return err
 }
+
+func UpdatePost(id int, content string) (err error) {
+	post, err := ShowPost(id)
+	if err != nil {
+		return err
+	}
+	postAfter := post
+	postAfter.Content = content
+	validate := validator.New()
+	err = validate.Struct(postAfter)
+	if err != nil {
+		return err
+	}
+	db.Model(&post).Updates(postAfter)
+	return nil
+}

--- a/models/post.go
+++ b/models/post.go
@@ -45,3 +45,12 @@ func UpdatePost(id int, content string) (err error) {
 	db.Model(&post).Updates(postAfter)
 	return nil
 }
+
+func DeletePost(id int) (err error) {
+	post, err := ShowPost(id)
+	if err != nil {
+		return err
+	}
+	db.Delete(&post)
+	return nil
+}


### PR DESCRIPTION
## やったこと
- ルーティングの書き換え(HTTPメソッドを指定して、ハンドラと紐づけるようにした)
- PATCH /api/v1/posts/:id の実装
  対象のレコードが存在しなかったら404、バリデーションエラーで400、成功したら204を返す
- DELETE /api/v1/posts/:id の実装
  対象のレコードが存在しなかったら404、成功したら204を返す

## 動作確認(コマンドのみ)
- PATCH /api/v1/posts/:id
`curl -X PATCH -H "Content-Type: application/json" -d '{"Content":"update"}' localhost:8080/api/v1/posts/1 -v`
- DELETE /api/v1/posts/:id
` curl -X DELETE localhost:8080/api/v1/posts/1 -v`

## 備考
エラーハンドリングのベストな書き方が分からない

## 参考
- [【GORM】Go言語でORM触ってみた](https://qiita.com/chan-p/items/cf3e007b82cc7fce2d81)
- [レコードの更新](https://gorm.io/ja_JP/docs/update.html)
- [Go言語の型とreflect](https://qiita.com/atsaki/items/3554f5a0609c59a3e10d)
