### PR TITLE
JWTトークンでAPI保護

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/roaris/go_sns_api
 go 1.16
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBK
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb8WugfUU=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -1,16 +1,38 @@
 package handlers
 
 import (
-	"golang.org/x/crypto/bcrypt"
 	"encoding/json"
 	"net/http"
+	"os"
+	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/roaris/go_sns_api/models"
+	"golang.org/x/crypto/bcrypt"
 )
 
 type AuthRequest struct {
 	Email    string
 	Password string
+}
+
+type Token struct {
+	Token string `json:"token"`
+}
+
+// JWTトークンを生成する
+func GenerateToken(userID int, now time.Time) (string, error) {
+	/*
+		HMAC SHA-256を使用 sub(subject):識別子 iat(issued at):発行時刻 exp(expiration):有効期限
+		iatとexpはUNIXタイムスタンプを使う
+	*/
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": userID,
+		"iat": now.Unix(),
+		"exp": now.Add(time.Hour * 24).Unix(),
+	})
+	// 秘密鍵で署名を作成
+	return token.SignedString([]byte(os.Getenv("SECRET")))
 }
 
 func Authenticate(w http.ResponseWriter, r *http.Request) {
@@ -39,5 +61,10 @@ func Authenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// トークンを返す
+	token, _ := GenerateToken(user.ID, time.Now())
+	res, _ := json.Marshal(Token{token})
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	w.Write(res)
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/roaris/go_sns_api/handlers"
+	"github.com/roaris/go_sns_api/middlewares"
 )
 
 func main() {
@@ -16,9 +17,9 @@ func main() {
 
 	v1r := r.PathPrefix("/api/v1").Subrouter()
 	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostShow)
-	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(handlers.PostCreate)
-	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostUpdate)
-	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostDelete)
+	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(middlewares.AuthMiddleware(handlers.PostCreate))
+	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(middlewares.AuthMiddleware(handlers.PostUpdate))
+	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(middlewares.AuthMiddleware(handlers.PostDelete))
 	v1r.Methods(http.MethodPost).Path("/users").HandlerFunc(handlers.UserCreate)
 	v1r.Methods(http.MethodPost).Path("/auth").HandlerFunc(handlers.Authenticate)
 	http.ListenAndServe(":8080", r)

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -1,0 +1,59 @@
+package middlewares
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+// ヘッダからトークンを取得する
+func getTokenFromHeader(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", errors.New("authorization header not found")
+	}
+	bearer := "Bearer"
+	l := len(bearer)
+	if len(header) > l && header[:l] == bearer {
+		return header[l+1:], nil
+	}
+	return "", errors.New("invalid format token")
+}
+
+// JWTトークンの検証を行う
+func parseToken(signedString string) (int, error) {
+	token, err := jwt.Parse(signedString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(os.Getenv("SECRET")), nil
+	})
+	if err != nil {
+		return -1, err
+	}
+	claims := token.Claims.(jwt.MapClaims)
+	userID := claims["sub"].(float64)
+	return int(userID), err
+}
+
+// JWTトークンの検証を行うミドルウェア
+func AuthMiddleware(handler http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, err := getTokenFromHeader(r)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		userID, err := parseToken(token)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		fmt.Println(userID)
+		// todo: userIDをContextにセットする
+		handler(w, r)
+	}
+}


### PR DESCRIPTION
## やったこと
- POST /api/v1/authでJWTトークンを返却するようにした
  ユーザーIDと発行時刻と有効期限を含めている 有効期限は発行時刻の1日後としている
- 認証のミドルウェアを追加
  ミドルウェアはhttp.HandlerFuncを引数にして、http.HandlerFuncを返す関数として実装している
  このミドルウェアでPOST /api/v1/posts, PATCH /api/v1/posts/:id, DELETE /api/v1/posts/:id を保護している

## 動作確認
- POST /api/v1/auth

<img width="1179" alt="スクリーンショット 2022-01-29 2 29 13" src="https://user-images.githubusercontent.com/61813626/151593864-90add5bd-facc-48c9-a7d2-54c4927d8a80.png">

- API保護についても、正しく動作している(トークンが間違っていたり、有効期限切れだとステータス401が返る)

## 備考
JSONを返すのに毎回構造体を定義しないといけないのちょっと面倒

## 参考
- [Go: JWT の実装](https://qiita.com/ekzemplaro/items/bb76d7e210c62be298e4)
- [Go で JWT を使うユースケースとその実装例](https://qiita.com/yoheimuta/items/b17bfbac17c02d410f54)
- [HTTP Middleware の作り方と使い方](https://tutuz-tech.hatenablog.com/entry/2020/03/23/220326)
- [panic interface conversion interface {} is float64 not int64](https://stackoverflow.com/questions/70705673/panic-interface-conversion-interface-is-float64-not-int64)