### PR TITLE
投稿とユーザーを紐付ける

### DIFF
--- a/handlers/post.go
+++ b/handlers/post.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/jinzhu/gorm"
+	"github.com/roaris/go_sns_api/httputils"
 	"github.com/roaris/go_sns_api/models"
 	"gopkg.in/go-playground/validator.v9"
 )
@@ -46,7 +47,8 @@ func PostCreate(w http.ResponseWriter, r *http.Request) {
 	var postRequest PostRequest
 	json.Unmarshal(body, &postRequest)
 
-	err := models.CreatePost(r.Context().Value("userID").(int), postRequest.Content)
+	userID := httputils.GetUserIDFromContext(r.Context())
+	err := models.CreatePost(userID, postRequest.Content)
 
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -66,7 +68,8 @@ func PostUpdate(w http.ResponseWriter, r *http.Request) {
 	var postRequest PostRequest
 	json.Unmarshal(body, &postRequest)
 
-	err := models.UpdatePost(id, r.Context().Value("userID").(int), postRequest.Content)
+	userID := httputils.GetUserIDFromContext(r.Context())
+	err := models.UpdatePost(id, userID, postRequest.Content)
 
 	if gorm.IsRecordNotFoundError(err) {
 		w.WriteHeader(http.StatusNotFound)
@@ -87,7 +90,8 @@ func PostDelete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id, _ := strconv.Atoi(vars["id"])
 
-	err := models.DeletePost(id, r.Context().Value("userID").(int))
+	userID := httputils.GetUserIDFromContext(r.Context())
+	err := models.DeletePost(id, userID)
 	if gorm.IsRecordNotFoundError(err) {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -95,7 +95,7 @@ func PostDelete(w http.ResponseWriter, r *http.Request) {
 	if gorm.IsRecordNotFoundError(err) {
 		w.WriteHeader(http.StatusNotFound)
 		return
-	} else if err != nil && err.Error() == "forbidden update" {
+	} else if err != nil && err.Error() == "forbidden delete" {
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}

--- a/httputils/context.go
+++ b/httputils/context.go
@@ -1,0 +1,16 @@
+package httputils
+
+import "context"
+
+type contextKey string
+
+const userIDContextKey contextKey = "userID"
+
+func SetUserIDToContext(ctx context.Context, userID int) context.Context {
+	return context.WithValue(ctx, userIDContextKey, userID)
+}
+
+func GetUserIDFromContext(ctx context.Context) int {
+	userID := ctx.Value(userIDContextKey)
+	return userID.(int)
+}

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -1,10 +1,11 @@
 package middlewares
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"os"
+
+	"github.com/roaris/go_sns_api/httputils"
 
 	"github.com/dgrijalva/jwt-go"
 )
@@ -52,7 +53,7 @@ func AuthMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		ctx := context.WithValue(r.Context(), "userID", userID)
+		ctx := httputils.SetUserIDToContext(r.Context(), userID)
 		handler(w, r.WithContext(ctx))
 	}
 }

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -1,8 +1,8 @@
 package middlewares
 
 import (
+	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -52,8 +52,7 @@ func AuthMiddleware(handler http.HandlerFunc) http.HandlerFunc {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		fmt.Println(userID)
-		// todo: userIDをContextにセットする
-		handler(w, r)
+		ctx := context.WithValue(r.Context(), "userID", userID)
+		handler(w, r.WithContext(ctx))
 	}
 }

--- a/models/base.go
+++ b/models/base.go
@@ -29,6 +29,6 @@ func init() {
 		log.Fatalln(err)
 	}
 
-	db.AutoMigrate(&Post{}) // postsテーブルの作成
 	db.AutoMigrate(&User{}) // usersテーブルの作成
+	db.AutoMigrate(&Post{}).AddForeignKey("user_id", "users(id)", "CASCADE", "RESTRICT") // postsテーブルの作成, 対応するuserが削除されたらpostも削除される(CASCADE), user_idの更新は認めない(RESTRICT)
 }

--- a/models/post.go
+++ b/models/post.go
@@ -9,6 +9,8 @@ import (
 type Post struct {
 	ID        int       `json:"id"`
 	Content   string    `json:"content" validate:"required,max=140"`
+	UserID    int       `json:"user_id" validate:"required"`
+	User      User
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/models/post.go
+++ b/models/post.go
@@ -11,7 +11,7 @@ type Post struct {
 	ID        int       `json:"id"`
 	Content   string    `json:"content" validate:"required,max=140"`
 	UserID    int       `json:"user_id" validate:"required"`
-	User      User      `validate:"-"`
+	User      *User     `json:"user,omitempty" validate:"-"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	Name      string    `json:"name" validate:"required,min=3"`
 	Email     string    `json:"email" validate:"required,email" gorm:"unique_index"`
 	Password  string    `json:"password" validate:"required"`
+	Posts     []Post
 	CreatedAt time.Time `json:"created_at"`
 }
 


### PR DESCRIPTION
## やったこと
- postsテーブルにuser_idを追加して、外部キー制約をつけた
- AuthMiddlewareで特定したユーザーIDをcontext経由でハンドラに渡すようにした
  contextは`map[interface{}]interface{}`と同じであり、値の登録、取得の処理は、別パッケージにして型制限をつけるのが推奨される
  今回はhttputilsにcontextの処理を記述している
- POST /api/v1/posts でユーザーIDも含めて処理を行う
- PATCH /api/v1/posts/:id, DELETE /api/v1/posts/:id に投稿をしたユーザー以外がリクエストした場合は、ステータス403を返すようにした

## 参考
- [Belongs To](https://gorm.io/ja_JP/docs/belongs_to.html)
- [Has Many](https://gorm.io/ja_JP/docs/has_many.html)
- [【Go言語】GORMで外部キー制約を設定する](https://qiita.com/fukuyama012/items/b6457a7f71b4091f286f)
- [MySQLの外部キー制約RESTRICT,CASCADE,SET NULL,NO ACTIONの違いは？](https://qiita.com/suin/items/21fe6c5a78c1505b19cb)
- [【MySQL】既に作成されているテーブルからCREATE文を取得する](https://qiita.com/suin/items/21fe6c5a78c1505b19cb)
- [[Golang] 構造体 in 構造体のバリデーションについて](https://qiita.com/kiki-ki/items/5f8ec3e198f2d4b19e42)
- [Association で任意の外部キー名を使う](https://egawata.hatenablog.com/entry/2017/01/08/073313)
- [Go1.7のcontextパッケージ](https://deeeet.com/writing/2016/07/22/context/)
- [Golangのcontext.Valueの使い方](https://deeeet.com/writing/2017/02/23/go-context-value/)