### PR TITLE
CORSの設定

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jinzhu/gorm v1.9.16 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/rs/cors v1.8.2 // indirect
 	golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8 // indirect
 	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ic
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
+github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/roaris/go_sns_api/handlers"
 	"github.com/roaris/go_sns_api/middlewares"
+	"github.com/rs/cors"
 )
 
 func main() {
@@ -15,6 +16,21 @@ func main() {
 		w.Write([]byte("pong"))
 	})
 
+	// CORSの設定
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"Authorization", "Accept-Language", "Content-Type", "Content-Language", "Origin"},
+		AllowedMethods: []string{
+			http.MethodOptions,
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+	})
+
 	v1r := r.PathPrefix("/api/v1").Subrouter()
 	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.PostShow)
 	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(middlewares.AuthMiddleware(handlers.PostCreate))
@@ -22,5 +38,5 @@ func main() {
 	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(middlewares.AuthMiddleware(handlers.PostDelete))
 	v1r.Methods(http.MethodPost).Path("/users").HandlerFunc(handlers.UserCreate)
 	v1r.Methods(http.MethodPost).Path("/auth").HandlerFunc(handlers.Authenticate)
-	http.ListenAndServe(":8080", r)
+	http.ListenAndServe(":8080", c.Handler(r))
 }


### PR DESCRIPTION
## やったこと
- CORSの設定を行なった(main.go)
  net/httpだけでCORSの設定をしようとなると、プリフライトリクエストの時と通常のリクエストの時で、場合分けをしないといけない([参考](https://qiita.com/romot/items/b49f7d9e28101daaa99e))
[rs/cors](https://github.com/rs/cors)は、こうした場合分けを内部で処理してくれるものという認識
実際に見てみると、こんな感じのコードになっている

```go
func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
		c.logf("ServeHTTP: Preflight request")
		c.handlePreflight(w, r)
		// Preflight requests are standalone and should stop the chain as some other
		// middleware may not handle OPTIONS requests correctly. One typical example
		// is authentication middleware ; OPTIONS requests won't carry authentication
		// headers (see #1)
		if c.optionPassthrough {
			next(w, r)
		} else {
			w.WriteHeader(c.optionsSuccessStatus)
		}
	} else {
		c.logf("ServeHTTP: Actual request")
		c.handleActualRequest(w, r)
		next(w, r)
	}
}
```

OPTIONSメソッドでかつ、Access-Control-Request-Methodヘッダ(この後に行うリクエストのHTTPメソッド)が空でない時、`c.handlePreflight(w, r)`を実行するという風になっている

## 参考
- [rs/cors](https://github.com/rs/cors)
- [CORS とか Preflight とかよくわかんないよな](https://note.crohaco.net/2019/http-cors-preflight/)
- [GolangでXMLHttpRequestLevel2+CORSのプリフライトが通るサーバーを立てる(BasicAuth付き)](https://qiita.com/romot/items/b49f7d9e28101daaa99e)
