### PR TITLE
単体テストを書けるように、レスポンス作成部分を共通化する

### DIFF
--- a/httputils/error.go
+++ b/httputils/error.go
@@ -1,0 +1,5 @@
+package httputils
+
+type HTTPError struct {
+	Message string `json:"message"`
+}

--- a/httputils/response.go
+++ b/httputils/response.go
@@ -1,0 +1,29 @@
+package httputils
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func RespondJSON(w http.ResponseWriter, status int, payload interface{}) {
+	res, err := marshal(payload)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(res)
+}
+
+func RespondErrorJSON(w http.ResponseWriter, status int, err error) {
+	he := HTTPError{Message: err.Error()}
+	RespondJSON(w, status, he)
+}
+
+func marshal(payload interface{}) ([]byte, error) {
+	if payload == nil {
+		return []byte("{}"), nil
+	}
+	return json.Marshal(payload)
+}

--- a/main.go
+++ b/main.go
@@ -32,13 +32,16 @@ func main() {
 	})
 
 	v1r := r.PathPrefix("/api/v1").Subrouter()
-	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(middlewares.AuthMiddleware(handlers.CreatePost))
-	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(handlers.GetPost)
-	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(middlewares.AuthMiddleware(handlers.UpdatePost))
-	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(middlewares.AuthMiddleware(handlers.DeletePost))
-	v1r.Methods(http.MethodPost).Path("/users").HandlerFunc(handlers.CreateUser)
-	v1r.Methods(http.MethodGet).Path("/users/me").HandlerFunc(middlewares.AuthMiddleware(handlers.GetLoginUser))
-	v1r.Methods(http.MethodPatch).Path("/users/me").HandlerFunc(middlewares.AuthMiddleware(handlers.UpdateLoginUser))
-	v1r.Methods(http.MethodPost).Path("/auth").HandlerFunc(handlers.Authenticate)
+
+	authMiddleware := middlewares.AuthMiddleware
+	responseMiddleware := middlewares.ResponseMiddleware
+	v1r.Methods(http.MethodPost).Path("/posts").HandlerFunc(authMiddleware(responseMiddleware(handlers.CreatePost)))
+	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").HandlerFunc(responseMiddleware(handlers.GetPost))
+	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").HandlerFunc(authMiddleware(responseMiddleware(handlers.UpdatePost)))
+	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").HandlerFunc(authMiddleware(responseMiddleware(handlers.DeletePost)))
+	v1r.Methods(http.MethodPost).Path("/users").HandlerFunc(responseMiddleware(handlers.CreateUser))
+	v1r.Methods(http.MethodGet).Path("/users/me").HandlerFunc(authMiddleware(responseMiddleware(handlers.GetLoginUser)))
+	v1r.Methods(http.MethodPatch).Path("/users/me").HandlerFunc(authMiddleware(responseMiddleware(handlers.UpdateLoginUser)))
+	v1r.Methods(http.MethodPost).Path("/auth").HandlerFunc(responseMiddleware(handlers.Authenticate))
 	http.ListenAndServe(":8080", c.Handler(r))
 }

--- a/middlewares/response.go
+++ b/middlewares/response.go
@@ -1,0 +1,21 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/roaris/go-sns-api/httputils"
+)
+
+type handler func(w http.ResponseWriter, r *http.Request) (int, interface{}, error)
+
+// レスポンスを作成するミドルウェア
+func ResponseMiddleware(h handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		status, payload, err := h(w, r)
+		if err != nil {
+			httputils.RespondErrorJSON(w, status, err)
+			return
+		}
+		httputils.RespondJSON(w, status, payload)
+	}
+}


### PR DESCRIPTION
## やったこと
- レスポンスを作成するミドルウェアを追加(ResponseMiddleware)
  リクエスト成功時はこれまでと動作は変わらず
  エラーが発生した場合は、`{"message": <エラーメッセージ>}`の形のJSONが返る
- 各ハンドラのレスポンス作成部分をミドルウェアに移した
  各ハンドラの戻り値を(int, interface{}, error)に統一

## 動作確認
Swaggerで確認した

## 備考
- シンプルに実装するためにミドルウェアという形でレスポンス作成部分を切り出したけど、なんか違う気がする
- エラーが発生した時に返るJSONのメッセージが分かりにくいので、カスタマイズした方が良さそう(httputilsに実装した`HTTPError`で可能)
