### PR TITLE
いいね機能の実装

### DIFF
--- a/handlers/like.go
+++ b/handlers/like.go
@@ -1,0 +1,41 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/roaris/go-sns-api/httputils"
+	"github.com/roaris/go-sns-api/models"
+
+	"github.com/gorilla/mux"
+	"gorm.io/gorm"
+)
+
+type LikeHandler struct {
+	db *gorm.DB
+}
+
+func NewLikeHandler(db *gorm.DB) *LikeHandler {
+	return &LikeHandler{db}
+}
+
+func (l *LikeHandler) Create(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
+	vars := mux.Vars(r)
+	postID, err := strconv.ParseInt(vars["id"], 10, 64)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	userID := httputils.GetUserIDFromContext(r.Context())
+	if err := models.CreateLike(l.db, userID, postID); err != nil {
+		errCode := "Error XXXX"
+		l := len(errCode)
+		errMessage := err.Error()
+		if len(errMessage) >= l && errMessage[:l] == "Error 1062" { // ユニーク制約に違反する
+			return http.StatusConflict, nil, err
+		} else if len(errMessage) >= l && errMessage[:l] == "Error 1452" { // 外部キー制約に違反する
+			return http.StatusNotFound, nil, err
+		}
+	}
+	return http.StatusCreated, nil, nil
+}

--- a/handlers/like.go
+++ b/handlers/like.go
@@ -39,3 +39,17 @@ func (l *LikeHandler) Create(w http.ResponseWriter, r *http.Request) (int, inter
 	}
 	return http.StatusCreated, nil, nil
 }
+
+func (l *LikeHandler) Destroy(w http.ResponseWriter, r *http.Request) (int, interface{}, error) {
+	vars := mux.Vars(r)
+	postID, err := strconv.ParseInt(vars["id"], 10, 64)
+	if err != nil {
+		return http.StatusBadRequest, nil, err
+	}
+
+	userID := httputils.GetUserIDFromContext(r.Context())
+	if err = models.DeleteLike(l.db, userID, postID); err != nil {
+		return http.StatusNotFound, nil, err
+	}
+	return http.StatusOK, nil, nil
+}

--- a/handlers/like_test.go
+++ b/handlers/like_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/roaris/go-sns-api/httputils"
+	"github.com/roaris/go-sns-api/models"
+	"github.com/roaris/go-sns-api/swagger/gen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateLike(t *testing.T) {
+	t.Run("created", func(t *testing.T) {
+		db := models.CreateTestDB()
+		defer models.CleanUpTestDB(db)
+
+		user1, _ := models.CreateUser(db, "alice", "alice@example.com", "password")
+		user2, _ := models.CreateUser(db, "bob", "bob@example.com", "password")
+		post, _ := models.CreatePost(db, user2.ID, "I'm happy.")
+
+		// before
+		postHandler := NewPostHandler(db)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/posts/%d", post.ID), nil)
+		vars := map[string]string{
+			"id": strconv.FormatInt(post.ID, 10),
+		}
+		r = mux.SetURLVars(r, vars)
+		ctx := httputils.SetUserIDToContext(r.Context(), user1.ID)
+		w := httptest.NewRecorder()
+		_, payload, _ := postHandler.Show(w, r.WithContext(ctx))
+
+		assert.Equal(t, int64(0), *payload.(gen.PostAndUser).Post.LikeNum)
+		assert.Equal(t, false, *payload.(gen.PostAndUser).Post.IsLiked)
+
+		// いいねする
+		likeHandler := NewLikeHandler(db)
+		r = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/posts/%d/likes", post.ID), nil)
+		status, payload, err := likeHandler.Create(w, r.WithContext(ctx))
+
+		assert.Equal(t, 201, status)
+		assert.Equal(t, nil, payload)
+		assert.Equal(t, nil, err)
+
+		// after
+		r = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/posts/%d", post.ID), nil)
+		_, payload, _ = postHandler.Show(w, r.WithContext(ctx))
+
+		assert.Equal(t, int64(1), *payload.(gen.PostAndUser).Post.LikeNum)
+		assert.Equal(t, true, *payload.(gen.PostAndUser).Post.IsLiked)
+	})
+
+	t.Run("conflict", func(t *testing.T) {
+		db := models.CreateTestDB()
+		defer models.CleanUpTestDB(db)
+
+		user1, _ := models.CreateUser(db, "alice", "alice@example.com", "password")
+		user2, _ := models.CreateUser(db, "bob", "bob@example.com", "password")
+		post, _ := models.CreatePost(db, user2.ID, "I'm happy.")
+		models.CreateLike(db, user1.ID, post.ID)
+
+		// before
+		postHandler := NewPostHandler(db)
+		r := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/posts/%d", post.ID), nil)
+		vars := map[string]string{
+			"id": strconv.FormatInt(post.ID, 10),
+		}
+		r = mux.SetURLVars(r, vars)
+		ctx := httputils.SetUserIDToContext(r.Context(), user1.ID)
+		w := httptest.NewRecorder()
+		_, payload, _ := postHandler.Show(w, r.WithContext(ctx))
+
+		assert.Equal(t, int64(1), *payload.(gen.PostAndUser).Post.LikeNum)
+		assert.Equal(t, true, *payload.(gen.PostAndUser).Post.IsLiked)
+
+		// いいねする(既にしているので失敗)
+		likeHandler := NewLikeHandler(db)
+		r = httptest.NewRequest("POST", fmt.Sprintf("/api/v1/posts/%d/likes", post.ID), nil)
+		status, payload, err := likeHandler.Create(w, r.WithContext(ctx))
+
+		assert.Equal(t, 409, status)
+		assert.Equal(t, nil, payload)
+		assert.NotEqual(t, nil, err)
+
+		// after
+		r = httptest.NewRequest("GET", fmt.Sprintf("/api/v1/posts/%d", post.ID), nil)
+		_, payload, _ = postHandler.Show(w, r.WithContext(ctx))
+
+		assert.Equal(t, int64(1), *payload.(gen.PostAndUser).Post.LikeNum)
+		assert.Equal(t, true, *payload.(gen.PostAndUser).Post.IsLiked)
+	})
+}

--- a/handlers/post_test.go
+++ b/handlers/post_test.go
@@ -90,8 +90,9 @@ func TestShowPost(t *testing.T) {
 			"id": strconv.FormatInt(post.ID, 10),
 		}
 		r = mux.SetURLVars(r, vars)
+		ctx := httputils.SetUserIDToContext(r.Context(), user.ID)
 		w := httptest.NewRecorder()
-		status, payload, err := postHandler.Show(w, r)
+		status, payload, err := postHandler.Show(w, r.WithContext(ctx))
 
 		assert.Equal(t, 200, status)
 		assert.Equal(t, post.Content, payload.(gen.PostAndUser).Post.Content)
@@ -111,9 +112,10 @@ func TestShowPost(t *testing.T) {
 		vars := map[string]string{
 			"id": strconv.FormatInt(post.ID+1, 10),
 		}
+		ctx := httputils.SetUserIDToContext(r.Context(), user.ID)
 		r = mux.SetURLVars(r, vars)
 		w := httptest.NewRecorder()
-		status, payload, err := postHandler.Show(w, r)
+		status, payload, err := postHandler.Show(w, r.WithContext(ctx))
 
 		assert.Equal(t, 404, status)
 		assert.Equal(t, nil, payload)
@@ -146,8 +148,8 @@ func TestIndexPost(t *testing.T) {
 
 		assert.Equal(t, 200, status)
 		assert.Equal(t, 2, len(payload.(gen.PostsAndUsers).PostsAndUsers))
-		assert.Equal(t, post1.SwaggerModel().Content, payload.(gen.PostsAndUsers).PostsAndUsers[0].Post.Content)
-		assert.Equal(t, post2.SwaggerModel().Content, payload.(gen.PostsAndUsers).PostsAndUsers[1].Post.Content)
+		assert.Equal(t, post1.Content, payload.(gen.PostsAndUsers).PostsAndUsers[0].Post.Content)
+		assert.Equal(t, post2.Content, payload.(gen.PostsAndUsers).PostsAndUsers[1].Post.Content)
 		assert.Equal(t, nil, err)
 	})
 

--- a/main.go
+++ b/main.go
@@ -56,5 +56,6 @@ func main() {
 	v1r.Methods(http.MethodGet).Path("/users/{id:[0-9]+}/followers").Handler(AppHandler{friendshipHandler.ShowFollowers})
 	v1r.Methods(http.MethodDelete).Path("/users/me/followees/{id:[0-9]+}").Handler(authMiddleware(AppHandler{friendshipHandler.Destroy}))
 	v1r.Methods(http.MethodPost).Path("/posts/{id:[0-9]+}/likes").Handler(authMiddleware(AppHandler{likeHandler.Create}))
+	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}/likes").Handler(authMiddleware(AppHandler{likeHandler.Destroy}))
 	http.ListenAndServe(":8080", c.Handler(r))
 }

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	authMiddleware := middlewares.AuthMiddleware
 	v1r.Methods(http.MethodPost).Path("/posts").Handler(authMiddleware(AppHandler{postHandler.Create}))
-	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").Handler(AppHandler{postHandler.Show})
+	v1r.Methods(http.MethodGet).Path("/posts/{id:[0-9]+}").Handler(authMiddleware(AppHandler{postHandler.Show}))
 	v1r.Methods(http.MethodGet).Path("/posts").Queries("limit", "{limit:[0-9]+}", "offset", "{offset:[0-9]+}").Handler(authMiddleware(AppHandler{postHandler.Index}))
 	v1r.Methods(http.MethodPatch).Path("/posts/{id:[0-9]+}").Handler(authMiddleware(AppHandler{postHandler.Update}))
 	v1r.Methods(http.MethodDelete).Path("/posts/{id:[0-9]+}").Handler(authMiddleware(AppHandler{postHandler.Destroy}))

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	friendshipHandler := handlers.NewFriendshipHandler(db)
 	postHandler := handlers.NewPostHandler(db)
 	userHandler := handlers.NewUserHandler(db)
+	likeHandler := handlers.NewLikeHandler(db)
 
 	v1r := r.PathPrefix("/api/v1").Subrouter()
 
@@ -54,5 +55,6 @@ func main() {
 	v1r.Methods(http.MethodGet).Path("/users/{id:[0-9]+}/followees").Handler(AppHandler{friendshipHandler.ShowFollowees})
 	v1r.Methods(http.MethodGet).Path("/users/{id:[0-9]+}/followers").Handler(AppHandler{friendshipHandler.ShowFollowers})
 	v1r.Methods(http.MethodDelete).Path("/users/me/followees/{id:[0-9]+}").Handler(authMiddleware(AppHandler{friendshipHandler.Destroy}))
+	v1r.Methods(http.MethodPost).Path("/posts/{id:[0-9]+}/likes").Handler(authMiddleware(AppHandler{likeHandler.Create}))
 	http.ListenAndServe(":8080", c.Handler(r))
 }

--- a/models/base.go
+++ b/models/base.go
@@ -30,7 +30,7 @@ func CreateDB() (db *gorm.DB) {
 		log.Fatalln(err)
 	}
 
-	db.AutoMigrate(&User{}, &Post{}, &Friendship{})
+	db.AutoMigrate(&User{}, &Post{}, &Friendship{}, &Like{})
 	return db
 }
 
@@ -53,12 +53,13 @@ func CreateTestDB() (db *gorm.DB) {
 		log.Fatalln(err)
 	}
 
-	db.AutoMigrate(&User{}, &Post{}, &Friendship{})
+	db.AutoMigrate(&User{}, &Post{}, &Friendship{}, &Like{})
 	return db
 }
 
 func CleanUpTestDB(db *gorm.DB) {
 	// 順番に注意!
+	db.Migrator().DropTable(&Like{})
 	db.Migrator().DropTable(&Post{})
 	db.Migrator().DropTable(&Friendship{})
 	db.Migrator().DropTable(&User{})

--- a/models/like.go
+++ b/models/like.go
@@ -1,0 +1,9 @@
+package models
+
+type Like struct {
+	ID     int64
+	UserID int64 `gorm:"index:idx_like,unique"`
+	User   User  `gorm:"constraint:OnUpdate:RESTRICT,OnDelete:CASCADE"`
+	PostID int64 `gorm:"index:idx_like,unique"`
+	Post   Post  `gorm:"constraint:OnUpdate:RESTRICT,OnDelete:CASCADE"`
+}

--- a/models/like.go
+++ b/models/like.go
@@ -17,3 +17,12 @@ func CreateLike(db *gorm.DB, userID int64, postID int64) error {
 	}).Error
 	return err
 }
+
+func DeleteLike(db *gorm.DB, userID int64, postID int64) error {
+	var like Like
+	if err := db.First(&like, "user_id = ? & post_id = ?", userID, postID).Error; err != nil {
+		return err
+	}
+	db.Delete(&like)
+	return nil
+}

--- a/models/like.go
+++ b/models/like.go
@@ -26,3 +26,52 @@ func DeleteLike(db *gorm.DB, userID int64, postID int64) error {
 	db.Delete(&like)
 	return nil
 }
+
+func IsLiked(db *gorm.DB, userID int64, postID int64) bool {
+	var like Like
+	if err := db.First(&like, "user_id = ? & post_id = ?", userID, postID).Error; err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func BulkIsLiked(db *gorm.DB, userID int64, postIDs []int64) (flags []bool) {
+	var likes []Like
+	db.Model(&Like{}).Where("user_id = ? & post_id IN ?", userID, postIDs).Find(&likes)
+	m := map[int64]struct{}{} // setの代用
+	for _, like := range likes {
+		m[like.PostID] = struct{}{}
+	}
+	for _, postID := range postIDs {
+		_, ok := m[postID]
+		if ok {
+			flags = append(flags, true)
+		} else {
+			flags = append(flags, false)
+		}
+	}
+	return flags
+}
+
+func GetLikeNum(db *gorm.DB, postID int64) int64 {
+	var count int64
+	db.Model(&Like{}).Where("post_id = ?", postID).Count(&count)
+	return count
+}
+
+func BulkGetLikeNum(db *gorm.DB, postIDs []int64) (nums []int64) {
+	var postIDsAndNums []struct {
+		PostID int64
+		Count  int64
+	}
+	db.Model(&Like{}).Select("post_id, COUNT(*) AS count").Where("post_id IN ?", postIDs).Group("post_id").Find(&postIDsAndNums)
+	m := map[int64]int64{}
+	for _, postIDAndNum := range postIDsAndNums {
+		m[postIDAndNum.PostID] = postIDAndNum.Count
+	}
+	for _, postID := range postIDs {
+		nums = append(nums, m[postID])
+	}
+	return nums
+}

--- a/models/like.go
+++ b/models/like.go
@@ -1,9 +1,19 @@
 package models
 
+import "gorm.io/gorm"
+
 type Like struct {
 	ID     int64
 	UserID int64 `gorm:"index:idx_like,unique"`
 	User   User  `gorm:"constraint:OnUpdate:RESTRICT,OnDelete:CASCADE"`
 	PostID int64 `gorm:"index:idx_like,unique"`
 	Post   Post  `gorm:"constraint:OnUpdate:RESTRICT,OnDelete:CASCADE"`
+}
+
+func CreateLike(db *gorm.DB, userID int64, postID int64) error {
+	err := db.Create(&Like{
+		UserID: userID,
+		PostID: postID,
+	}).Error
+	return err
 }

--- a/models/post.go
+++ b/models/post.go
@@ -18,11 +18,13 @@ type Post struct {
 	UpdatedAt time.Time
 }
 
-func (p *Post) SwaggerModel() *gen.Post {
+func (p *Post) SwaggerModel(isLiked bool, likeNum int64) *gen.Post {
 	return &gen.Post{
 		ID:        p.ID,
 		Content:   p.Content,
 		UserID:    p.UserID,
+		IsLiked:   &isLiked,
+		LikeNum:   &likeNum,
 		CreatedAt: strfmt.DateTime(p.CreatedAt),
 		UpdatedAt: strfmt.DateTime(p.UpdatedAt),
 	}

--- a/swagger/gen/post.go
+++ b/swagger/gen/post.go
@@ -29,6 +29,14 @@ type Post struct {
 	// id
 	ID int64 `json:"id,omitempty"`
 
+	// is liked
+	// Required: true
+	IsLiked *bool `json:"is_liked"`
+
+	// like num
+	// Required: true
+	LikeNum *int64 `json:"like_num"`
+
 	// updated at
 	// Format: date-time
 	UpdatedAt strfmt.DateTime `json:"updated_at,omitempty"`
@@ -42,6 +50,14 @@ func (m *Post) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateCreatedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateIsLiked(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateLikeNum(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -61,6 +77,24 @@ func (m *Post) validateCreatedAt(formats strfmt.Registry) error {
 	}
 
 	if err := validate.FormatOf("created_at", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Post) validateIsLiked(formats strfmt.Registry) error {
+
+	if err := validate.Required("is_liked", "body", m.IsLiked); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Post) validateLikeNum(formats strfmt.Registry) error {
+
+	if err := validate.Required("like_num", "body", m.LikeNum); err != nil {
 		return err
 	}
 

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -331,6 +331,24 @@ paths:
             properties: {}
       operationId: get-users-user_id-followers
       description: フォローされているユーザー一覧
+  '/posts/{post_id}/likes':
+    parameters:
+      - type: string
+        name: post_id
+        in: path
+        required: true
+    post:
+      summary: ''
+      operationId: post-posts-post_id-likes
+      responses:
+        '201':
+          description: Created
+      tags:
+        - Post
+      description: 投稿にいいねをする
+      parameters: []
+      security:
+        - Authorization: []
 schemes:
   - http
 definitions:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -349,6 +349,17 @@ paths:
       parameters: []
       security:
         - Authorization: []
+    delete:
+      summary: ''
+      operationId: delete-posts-post_id-likes
+      responses:
+        '200':
+          description: OK
+      description: 投稿へのいいね削除
+      security:
+        - Authorization: []
+      tags:
+        - Post
 schemes:
   - http
 definitions:

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -33,6 +33,8 @@ paths:
       operationId: get-posts
       description: 投稿取得
       parameters: []
+      security:
+        - Authorization: []
     parameters:
       - type: string
         name: post_id
@@ -379,6 +381,13 @@ definitions:
       updated_at:
         type: string
         format: date-time
+      is_liked:
+        type: boolean
+      like_num:
+        type: integer
+    required:
+      - is_liked
+      - like_num
   User:
     title: User
     type: object


### PR DESCRIPTION
## やったこと
- likesテーブルの作成
  user_idとpost_idを持たせて、ユニークインデックスを作成している
- POST /api/v1/posts/:id/likes
  成功時は201, 既にいいね済みの場合は409, 存在しない投稿を指定した場合は404を返す
- DELETE /api/v1/posts/:id/likes
  成功時は200, いいねしていない場合(存在しない投稿を指定した場合も含む)は404を返す
- レスポンスの投稿にいいねしたかのフラグといいね数を持たせるようにした
  このために、GET /api/v1/posts/:id をトークン保護した
  タイムラインの取得(GET /api/v1/posts)では、普通にフラグといいね数を取得するとN+1になるので、IN句を使った(下手な実装になっていると思う)
- likeHanderのテスト作成
  いいね作成/削除の前後のGET /api/v1/posts/:id のレスポンスもチェックしている

## 動作確認
作成したテストが通ることを確認した

## 参考
- [Go言語での集合(Set)の扱い方とテスト](https://qiita.com/kotaroooo0/items/fe63ecc68723ab6ee81f)
- [Golang 所感とTips](https://qiita.com/castaneai/items/3419b9e62475f967de56)
- [Golang の panic: assignment to entry in nil map の対応](http://psychedelicnekopunch.com/archives/1509)